### PR TITLE
feat: Add admin management endpoints

### DIFF
--- a/atwood_monitor/atwood_monitor_stack.py
+++ b/atwood_monitor/atwood_monitor_stack.py
@@ -14,6 +14,9 @@ from .lambdas import (
     create_status_lambda,
     create_subscribe_lambda,
     create_web_push_lambda,
+    create_admin_stats_lambda,
+    create_admin_delete_lambda,
+    create_admin_authorizer_lambda,
 )
 from .monitoring import setup_dashboard
 from .storage import create_tables
@@ -61,6 +64,13 @@ class AtwoodMonitorStack(Stack):
         register_web_push_lambda = create_register_web_push_lambda(
             self, lambda_role, web_push_table, env_config
         )
+        admin_stats_lambda = create_admin_stats_lambda(
+            self, lambda_role, lambda_layer, users_table, web_push_table, env_config
+        )
+        admin_delete_lambda = create_admin_delete_lambda(
+            self, lambda_role, lambda_layer, users_table, web_push_table, env_config
+        )
+        admin_auth_lambda = create_admin_authorizer_lambda(self, lambda_role, env_config)
 
         # EventBridge trigger for scraping with environment-specific schedule
         rule = events.Rule(
@@ -76,6 +86,9 @@ class AtwoodMonitorStack(Stack):
             status_lambda=status_lambda,
             subscribe_lambda=subscribe_lambda,
             register_web_push_lambda=register_web_push_lambda,
+            admin_stats_lambda=admin_stats_lambda,
+            admin_delete_lambda=admin_delete_lambda,
+            admin_auth_lambda=admin_auth_lambda,
             env_config=env_config,
         )
 

--- a/atwood_monitor/environments.py
+++ b/atwood_monitor/environments.py
@@ -15,6 +15,7 @@ class EnvironmentConfig:
     monitoring_enabled: bool = True
     debug_mode: bool = False
     scraper_schedule: str = "rate(1 minute)"  # Default scraping frequency
+    admin_secret_param: str = "/atwood/admin_secret"
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert config to dictionary for CDK context."""
@@ -27,6 +28,7 @@ class EnvironmentConfig:
             "monitoring_enabled": self.monitoring_enabled,
             "debug_mode": self.debug_mode,
             "scraper_schedule": self.scraper_schedule,
+            "admin_secret_param": self.admin_secret_param,
         }
 
     @property
@@ -68,6 +70,7 @@ def get_environment_config(env_name: Optional[str] = None) -> EnvironmentConfig:
             monitoring_enabled=True,
             debug_mode=True,
             scraper_schedule="rate(2 minutes)",  # Less frequent for staging
+            admin_secret_param="/atwood/staging/admin_secret",
         )
     elif env_name == "production":
         return EnvironmentConfig(
@@ -79,6 +82,7 @@ def get_environment_config(env_name: Optional[str] = None) -> EnvironmentConfig:
             monitoring_enabled=True,
             debug_mode=False,
             scraper_schedule="rate(1 minute)",
+            admin_secret_param="/atwood/production/admin_secret",
         )
     else:
         # If an invalid environment is specified, raise an error

--- a/atwood_monitor/lambdas.py
+++ b/atwood_monitor/lambdas.py
@@ -175,3 +175,63 @@ def create_web_push_lambda(
     )
 
     return webpush_lambda
+
+def create_admin_stats_lambda(scope: Construct, role, layer, users_table, web_push_table, env_config: EnvironmentConfig) -> lambda_.Function:
+    fn = lambda_.Function(
+        scope,
+        "AdminStatsLambda",
+        function_name=f"{env_config.resource_name_prefix}-admin-stats",
+        runtime=lambda_.Runtime.PYTHON_3_11,
+        handler="admin_stats.lambda_handler",
+        code=lambda_.Code.from_asset("lambda"),
+        environment={
+            "USERS_TABLE": users_table.table_name,
+            "WEB_PUSH_TABLE": web_push_table.table_name,
+            "ENVIRONMENT": env_config.name,
+            "DEBUG": str(env_config.debug_mode).lower(),
+        },
+        layers=[layer],
+        role=role,
+    )
+    users_table.grant_read_data(fn)
+    web_push_table.grant_read_data(fn)
+    return fn
+
+
+def create_admin_delete_lambda(scope: Construct, role, layer, users_table, web_push_table, env_config: EnvironmentConfig) -> lambda_.Function:
+    fn = lambda_.Function(
+        scope,
+        "AdminDeleteLambda",
+        function_name=f"{env_config.resource_name_prefix}-admin-delete",
+        runtime=lambda_.Runtime.PYTHON_3_11,
+        handler="admin_delete.lambda_handler",
+        code=lambda_.Code.from_asset("lambda"),
+        environment={
+            "USERS_TABLE": users_table.table_name,
+            "WEB_PUSH_TABLE": web_push_table.table_name,
+            "ENVIRONMENT": env_config.name,
+            "DEBUG": str(env_config.debug_mode).lower(),
+        },
+        layers=[layer],
+        role=role,
+    )
+    users_table.grant_write_data(fn)
+    web_push_table.grant_write_data(fn)
+    return fn
+
+
+def create_admin_authorizer_lambda(scope: Construct, role, env_config: EnvironmentConfig) -> lambda_.Function:
+    fn = lambda_.Function(
+        scope,
+        "AdminAuthorizerLambda",
+        function_name=f"{env_config.resource_name_prefix}-admin-authorizer",
+        runtime=lambda_.Runtime.PYTHON_3_11,
+        handler="admin_auth.lambda_handler",
+        code=lambda_.Code.from_asset("lambda"),
+        environment={
+            "ADMIN_SECRET_PARAM": env_config.admin_secret_param,
+            "ENVIRONMENT": env_config.name,
+        },
+        role=role,
+    )
+    return fn

--- a/elm-frontend/admin/index.html
+++ b/elm-frontend/admin/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Admin Panel</title>
+</head>
+<body>
+  <h1>Admin Panel</h1>
+  <div>
+    <label>Secret: <input id="secret" type="password"></label>
+    <button id="load">Load Stats</button>
+  </div>
+  <pre id="stats"></pre>
+  <h2>Delete Entry</h2>
+  <input id="deleteId" placeholder="Email or subscription id">
+  <button id="deleteBtn">Delete</button>
+  <pre id="result"></pre>
+<script>
+const API_BASE_URL = 'API_BASE_URL_PLACEHOLDER';
+
+document.getElementById('load').onclick = async () => {
+  const secret = document.getElementById('secret').value;
+  const res = await fetch(`${API_BASE_URL}/admin`, {headers: {Authorization: secret}});
+  document.getElementById('stats').textContent = await res.text();
+};
+
+document.getElementById('deleteBtn').onclick = async () => {
+  const secret = document.getElementById('secret').value;
+  const id = document.getElementById('deleteId').value;
+  const res = await fetch(`${API_BASE_URL}/admin`, {
+    method: 'DELETE',
+    headers: {'Content-Type': 'application/json', Authorization: secret},
+    body: JSON.stringify({email: id, subscription_id: id})
+  });
+  document.getElementById('result').textContent = await res.text();
+};
+</script>
+</body>
+</html>

--- a/elm-frontend/build.sh
+++ b/elm-frontend/build.sh
@@ -45,6 +45,9 @@ npx --yes elm make src/Main.elm --output=dist/elm.js --optimize
 
 # Copy public files to dist
 cp -r public/* dist/
+mkdir -p dist/admin
+cp admin/index.html dist/admin/
+sed -i "s|API_BASE_URL_PLACEHOLDER|$API_BASE_URL|g" dist/admin/index.html
 
 # Replace API URL in index.html as well
 sed "s|https://b3q0v6btng.execute-api.eu-north-1.amazonaws.com/prod|$API_BASE_URL|g" dist/index.html > dist/index.html.tmp

--- a/lambda/admin_auth.py
+++ b/lambda/admin_auth.py
@@ -1,0 +1,24 @@
+import os
+import boto3
+
+ssm = boto3.client("ssm")
+param_name = os.environ["ADMIN_SECRET_PARAM"]
+
+
+def lambda_handler(event, context):
+    token = event.get("headers", {}).get("Authorization")
+    secret = ssm.get_parameter(Name=param_name, WithDecryption=True)["Parameter"]["Value"]
+    effect = "Allow" if token == secret else "Deny"
+    return {
+        "principalId": "admin",
+        "policyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "execute-api:Invoke",
+                    "Effect": effect,
+                    "Resource": event["methodArn"],
+                }
+            ],
+        },
+    }

--- a/lambda/admin_delete.py
+++ b/lambda/admin_delete.py
@@ -1,0 +1,32 @@
+import json
+import os
+
+import boto3
+
+
+dynamodb = boto3.resource("dynamodb")
+users_table = dynamodb.Table(os.environ["USERS_TABLE"])
+web_push_table = dynamodb.Table(os.environ["WEB_PUSH_TABLE"])
+
+
+def lambda_handler(event, context):
+    body = json.loads(event.get("body", "{}"))
+    email = body.get("email")
+    sub_id = body.get("subscription_id")
+
+    if email:
+        users_table.delete_item(Key={"user_id": email})
+        return {
+            "statusCode": 200,
+            "headers": {"Access-Control-Allow-Origin": "*"},
+            "body": json.dumps({"deleted": email}),
+        }
+    if sub_id:
+        web_push_table.delete_item(Key={"subscription_id": sub_id})
+        return {
+            "statusCode": 200,
+            "headers": {"Access-Control-Allow-Origin": "*"},
+            "body": json.dumps({"deleted": sub_id}),
+        }
+
+    return {"statusCode": 400, "body": "No identifier provided"}

--- a/lambda/admin_stats.py
+++ b/lambda/admin_stats.py
@@ -1,0 +1,19 @@
+import json
+import os
+
+import boto3
+
+
+dynamodb = boto3.resource("dynamodb")
+users_table = dynamodb.Table(os.environ["USERS_TABLE"])
+web_push_table = dynamodb.Table(os.environ["WEB_PUSH_TABLE"])
+
+
+def lambda_handler(event, context):
+    users_count = users_table.scan(Select="COUNT")["Count"]
+    web_push_count = web_push_table.scan(Select="COUNT")["Count"]
+    return {
+        "statusCode": 200,
+        "headers": {"Access-Control-Allow-Origin": "*"},
+        "body": json.dumps({"users": users_count, "web_push": web_push_count}),
+    }

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -16,6 +16,9 @@ fi
 # Set environment and region
 export ENVIRONMENT=production
 export AWS_DEFAULT_REGION=eu-north-1
+if [ -n "$ADMIN_SECRET" ]; then
+  aws ssm put-parameter --name "/atwood/production/admin_secret" --value "$ADMIN_SECRET" --type "SecureString" --overwrite
+fi
 
 # Build the Lambda layer
 echo "📦 Building Lambda layer..."

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -8,6 +8,9 @@ echo "🚀 Deploying to Staging Environment"
 # Set environment and region
 export ENVIRONMENT=staging
 export AWS_DEFAULT_REGION=us-west-2
+if [ -n "$ADMIN_SECRET" ]; then
+  aws ssm put-parameter --name "/atwood/staging/admin_secret" --value "$ADMIN_SECRET" --type "SecureString" --overwrite
+fi
 
 # Build the Lambda layer
 echo "📦 Building Lambda layer..."

--- a/tests/test_admin_lambdas.py
+++ b/tests/test_admin_lambdas.py
@@ -1,0 +1,77 @@
+import json
+import os
+import importlib
+import sys
+
+import boto3
+from moto import mock_aws
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+LAMBDA_DIR = os.path.join(ROOT, "lambda")
+sys.path.insert(0, LAMBDA_DIR)
+
+
+def reload_module(name):
+    if name in sys.modules:
+        return importlib.reload(sys.modules[name])
+    return importlib.import_module(name)
+
+
+@mock_aws
+def test_admin_stats_counts():
+    ddb = boto3.client("dynamodb", region_name="us-east-1")
+    ddb.create_table(
+        TableName="Users",
+        KeySchema=[{"AttributeName": "user_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "user_id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    ddb.create_table(
+        TableName="WebPush",
+        KeySchema=[{"AttributeName": "subscription_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "subscription_id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    users_table = boto3.resource("dynamodb", region_name="us-east-1").Table("Users")
+    users_table.put_item(Item={"user_id": "a"})
+    users_table.put_item(Item={"user_id": "b"})
+    web_table = boto3.resource("dynamodb", region_name="us-east-1").Table("WebPush")
+    web_table.put_item(Item={"subscription_id": "x"})
+
+    os.environ["USERS_TABLE"] = "Users"
+    os.environ["WEB_PUSH_TABLE"] = "WebPush"
+
+    mod = reload_module("admin_stats")
+    result = mod.lambda_handler({}, None)
+    body = json.loads(result["body"])
+    assert body["users"] == 2
+    assert body["web_push"] == 1
+
+
+@mock_aws
+def test_admin_delete_user():
+    ddb = boto3.client("dynamodb", region_name="us-east-1")
+    ddb.create_table(
+        TableName="Users",
+        KeySchema=[{"AttributeName": "user_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "user_id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    ddb.create_table(
+        TableName="WebPush",
+        KeySchema=[{"AttributeName": "subscription_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "subscription_id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    table = boto3.resource("dynamodb", region_name="us-east-1").Table("Users")
+    table.put_item(Item={"user_id": "a"})
+
+    os.environ["USERS_TABLE"] = "Users"
+    os.environ["WEB_PUSH_TABLE"] = "WebPush"
+
+    mod = reload_module("admin_delete")
+    event = {"body": json.dumps({"email": "a"})}
+    result = mod.lambda_handler(event, None)
+    assert result["statusCode"] == 200
+    assert "Item" not in table.get_item(Key={"user_id": "a"})
+


### PR DESCRIPTION
## Summary
- create admin Lambda functions and authorizer
- expose `/admin` in API Gateway
- wire Lambdas into stack
- copy simple admin HTML during build
- push admin secret from deploy scripts
- add tests for new Lambdas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68556d6c21a88327962ec0175039ae99