### PR TITLE
fix: dependency workflow push permissions

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -9,7 +9,7 @@ on:
 permissions:
   issues: write
   pull-requests: write
-  contents: read
+  contents: write
 
 jobs:
   dependency-audit:


### PR DESCRIPTION
## Summary
- allow the dependency update workflow to push changes by granting contents: write permissions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857d6da3c748327909a167af85a354b