### PR TITLE
Fix gitignore for Elm dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ cdk.context.json
 # Elm generated files
 elm-frontend/elm-stuff/
 elm-frontend/node_modules/
+elm-frontend/dist/


### PR DESCRIPTION
## Summary
- ignore Elm dist folder in git

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6857db2790a48327b3687e88aa4438b5