### PR TITLE
chore: Add git hook for automatic formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ Pull requests and issues are welcome. For major changes, please open an issue fi
 
 ---
 
+## 🛠️ Git Hooks
+
+Run `./scripts/install-git-hooks.sh` once to install local git hooks. The `pre-commit` hook formats Python files using **black** and **isort** before they are committed. This keeps commits passing the CI formatting checks.
+
+---
+
 ## 📄 License
 
 MIT — see `LICENSE` file.

--- a/atwood_monitor/atwood_monitor_stack.py
+++ b/atwood_monitor/atwood_monitor_stack.py
@@ -6,13 +6,18 @@ from constructs import Construct
 from .api_gateway import setup_api_gateway
 from .environments import EnvironmentConfig
 from .frontend import setup_frontend
-
-from .lambdas import (create_admin_authorizer_lambda,
-                      create_admin_delete_lambda, create_admin_stats_lambda,
-                      create_lambda_layer, create_lambda_role,
-                      create_register_web_push_lambda, create_scraper_lambda,
-                      create_status_lambda, create_subscribe_lambda,
-                      create_web_push_lambda)
+from .lambdas import (
+    create_admin_authorizer_lambda,
+    create_admin_delete_lambda,
+    create_admin_stats_lambda,
+    create_lambda_layer,
+    create_lambda_role,
+    create_register_web_push_lambda,
+    create_scraper_lambda,
+    create_status_lambda,
+    create_subscribe_lambda,
+    create_web_push_lambda,
+)
 from .monitoring import setup_dashboard
 from .storage import create_tables
 

--- a/atwood_monitor/lambdas.py
+++ b/atwood_monitor/lambdas.py
@@ -176,7 +176,7 @@ def create_web_push_lambda(
 
     return webpush_lambda
 
-  
+
 def create_admin_stats_lambda(
     scope: Construct,
     role,

--- a/lambda/admin_delete.py
+++ b/lambda/admin_delete.py
@@ -3,7 +3,6 @@ import os
 
 import boto3
 
-
 dynamodb = boto3.resource("dynamodb")
 users_table = dynamodb.Table(os.environ["USERS_TABLE"])
 web_push_table = dynamodb.Table(os.environ["WEB_PUSH_TABLE"])

--- a/lambda/admin_stats.py
+++ b/lambda/admin_stats.py
@@ -3,7 +3,6 @@ import os
 
 import boto3
 
-
 dynamodb = boto3.resource("dynamodb")
 users_table = dynamodb.Table(os.environ["USERS_TABLE"])
 web_push_table = dynamodb.Table(os.environ["WEB_PUSH_TABLE"])

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Pre-commit hook to format Python files before committing
+
+BLACK_EXCLUDES="(out|cdk\.out|elm-frontend/node_modules)"
+
+if command -v black >/dev/null 2>&1 && command -v isort >/dev/null 2>&1; then
+    echo "Running black and isort..."
+    black . --exclude="$BLACK_EXCLUDES"
+    isort . --profile black
+    git add -A
+else
+    echo "Black or isort not installed; skipping formatting" >&2
+fi
+
+exit 0

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOOKS_DIR="$(git rev-parse --git-dir)/hooks"
+mkdir -p "$HOOKS_DIR"
+
+for hook in scripts/git-hooks/*; do
+    name=$(basename "$hook")
+    cp "$hook" "$HOOKS_DIR/$name"
+    chmod +x "$HOOKS_DIR/$name"
+done
+
+echo "Git hooks installed to $HOOKS_DIR"

--- a/tests/test_admin_lambdas.py
+++ b/tests/test_admin_lambdas.py
@@ -29,7 +29,6 @@ def test_admin_stats_counts():
     ddb.create_table(
         TableName="WebPush",
         KeySchema=[{"AttributeName": "subscription_id", "KeyType": "HASH"}],
-
         AttributeDefinitions=[
             {"AttributeName": "subscription_id", "AttributeType": "S"}
         ],
@@ -79,4 +78,3 @@ def test_admin_delete_user():
     result = mod.lambda_handler(event, None)
     assert result["statusCode"] == 200
     assert "Item" not in table.get_item(Key={"user_id": "a"})
-    


### PR DESCRIPTION
## Summary
- add post-commit hook to auto format Python code
- provide helper script to install hooks
- document hook usage in README
- apply import sorting required by new hook

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857e6724e388327b2cd7010f4401832